### PR TITLE
rpc: getblock fix

### DIFF
--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2616,7 +2616,7 @@ class RPC extends RPCBase {
       time: entry.time,
       mediantime: mtp,
       nonce: entry.nonce,
-      bits: entry.bits,
+      bits: hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
       previousblockhash: !entry.prevBlock.equals(consensus.ZERO_HASH)
@@ -2658,7 +2658,7 @@ class RPC extends RPCBase {
       time: entry.time,
       mediantime: mtp,
       nonce: entry.nonce,
-      bits: entry.bits,
+      bits: hex32(entry.bits),
       difficulty: toDifficulty(entry.bits),
       nTx: txs.length,
       chainwork: entry.chainwork.toString('hex', 64),

--- a/lib/node/rpc.js
+++ b/lib/node/rpc.js
@@ -2601,16 +2601,21 @@ class RPC extends RPCBase {
   async headerToJSON(entry) {
     const mtp = await this.chain.getMedianTime(entry);
     const next = await this.chain.getNextHash(entry.hash);
+    let confirmations = -1;
+
+    if (await this.chain.isMainChain(entry))
+      confirmations = this.chain.height - entry.height + 1;
 
     return {
       hash: entry.rhash(),
-      confirmations: this.chain.height - entry.height + 1,
+      confirmations: confirmations,
       height: entry.height,
       version: entry.version,
       versionHex: hex32(entry.version),
       merkleroot: util.revHex(entry.merkleRoot),
       time: entry.time,
       mediantime: mtp,
+      nonce: entry.nonce,
       bits: entry.bits,
       difficulty: toDifficulty(entry.bits),
       chainwork: entry.chainwork.toString('hex', 64),
@@ -2624,6 +2629,11 @@ class RPC extends RPCBase {
   async blockToJSON(entry, block, details) {
     const mtp = await this.chain.getMedianTime(entry);
     const next = await this.chain.getNextHash(entry.hash);
+
+    let confirmations = -1;
+    if (await this.chain.isMainChain(entry))
+      confirmations = this.chain.height - entry.height + 1;
+
     const txs = [];
 
     for (const tx of block.txs) {
@@ -2637,7 +2647,7 @@ class RPC extends RPCBase {
 
     return {
       hash: entry.rhash(),
-      confirmations: this.chain.height - entry.height + 1,
+      confirmations: confirmations,
       size: block.getSize(),
       height: entry.height,
       version: entry.version,
@@ -2647,8 +2657,10 @@ class RPC extends RPCBase {
       tx: txs,
       time: entry.time,
       mediantime: mtp,
+      nonce: entry.nonce,
       bits: entry.bits,
       difficulty: toDifficulty(entry.bits),
+      nTx: txs.length,
       chainwork: entry.chainwork.toString('hex', 64),
       previousblockhash: !entry.prevBlock.equals(consensus.ZERO_HASH)
         ? util.revHex(entry.prevBlock)

--- a/test/node-rpc-test.js
+++ b/test/node-rpc-test.js
@@ -1,0 +1,132 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const FullNode = require('../lib/node/fullnode');
+const NodeClient = require('../lib/client/node');
+const KeyRing = require('../lib/primitives/keyring');
+
+const ports = {
+  p2p: 49331,
+  node: 49332,
+  wallet: 49333
+};
+
+const node = new FullNode({
+  network: 'regtest',
+  apiKey: 'foo',
+  walletAuth: true,
+  memory: true,
+  workers: true,
+  workersSize: 2,
+  plugins: [require('../lib/wallet/plugin')],
+  port: ports.p2p,
+  httpPort: ports.node,
+  env: {
+    'BCASH_WALLET_HTTP_PORT': ports.wallet.toString()
+  }
+});
+
+const nclient = new NodeClient({
+  port: ports.node,
+  apiKey: 'foo',
+  timeout: 15000
+});
+
+describe('RPC', function() {
+  this.timeout(15000);
+
+  before(async () => {
+    await node.open();
+  });
+
+  after(async () => {
+    await node.close();
+  });
+
+  it('should rpc help', async () => {
+    assert(await nclient.execute('help', []));
+
+    await assert.rejects(async () => {
+      await nclient.execute('help', ['getinfo']);
+    }, {
+      name: 'Error',
+      message: /^getinfo/
+    });
+  });
+
+  it('should rpc getinfo', async () => {
+    const info = await nclient.execute('getinfo', []);
+    assert.strictEqual(info.blocks, 0);
+  });
+
+  describe('getblock', function () {
+    it('should rpc getblock', async () => {
+      const {chain} = await nclient.getInfo();
+      const info = await nclient.execute('getblock', [chain.tip]);
+
+      const properties = [
+        'hash', 'confirmations', 'strippedsize',
+        'size', 'weight', 'height', 'version',
+        'versionHex', 'merkleroot', 'coinbase',
+        'tx', 'time', 'mediantime', 'nonce',
+        'bits', 'difficulty', 'chainwork',
+        'nTx', 'previousblockhash', 'nextblockhash'
+      ];
+
+      assert.deepEqual(chain.height, info.height);
+      assert.deepEqual(chain.tip, info.hash);
+      assert.equal(info.bits, '207fffff');
+    });
+
+    it('should return correct height', async () => {
+      // Create an address to mine with.
+      const wallet = await node.plugins.walletdb.wdb.get(0);
+      const key = await wallet.createReceive(0);
+      const address = key.getAddress().toString(node.network.type);
+
+      // Mine two blocks.
+      await nclient.execute('generatetoaddress', [2, address]);
+
+      const {chain} = await nclient.getInfo();
+      const info = await nclient.execute('getblock', [chain.tip]);
+
+      // Assert the heights match.
+      assert.deepEqual(chain.height, info.height);
+    });
+
+    it('should return confirmations (main chain)', async () => {
+      const {chain} = await nclient.getInfo();
+
+      const {genesis} = node.network;
+      const hash = genesis.hash.reverse().toString('hex');
+
+      const info = await nclient.execute('getblock', [hash]);
+
+      assert.deepEqual(chain.height, info.confirmations - 1);
+    });
+
+    it('should return confirmations (orphan)', async () => {
+      // Get the current chain state
+      const {chain} = await nclient.getInfo();
+
+      // Get the chain entry associated with
+      // the genesis block.
+      const {genesis} = node.network;
+      let entry = await node.chain.getEntry(genesis.hash.reverse());
+
+      // Reorg from the genesis block.
+      for (let i = 0; i < chain.height + 1; i++) {
+        const block = await node.miner.mineBlock(entry);
+        await node.chain.add(block);
+        entry = await node.chain.getEntry(block.hash());
+      }
+
+      // Call getblock using the previous tip
+      const info = await nclient.execute('getblock', [chain.tip]);
+      assert.deepEqual(info.confirmations, -1);
+    });
+  });
+});


### PR DESCRIPTION
Referrence: https://github.com/bcoin-org/bcoin/pull/919

Fixes the confirmation field in both getblock and getblockheader. It is supposed to return -1 if the block is not in the main chain. This allows applications to be able to determine if blocks are in the main chain or not.

Includes tests for the RPC getblock.